### PR TITLE
Adding Centos Support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,11 +21,13 @@ consul_servers: ['127.0.0.1']
 consul_log_level: "INFO"
 consul_syslog: false
 consul_rejoin_after_leave: true
+consul_join_at_start: false
 consul_bind_address: "0.0.0.0"
 consul_client_address: "127.0.0.1"
-consul_node_name: "{{ ansible_default_ipv4['address'] }}"
+consul_node_name: "{{ inventory_hostname }}"
 consul_datacenter: "default"
 consul_ui_require_auth: false
 consul_ui_auth_user_file: /etc/htpasswd/consul
-consul_enable_nginx_config: true
+consul_enable_nginx_config: false
 consul_disable_remote_exec: true
+consul_consulate: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: restart consul
-  action: service name=consul state=restarted
+  service: name=consul state=started
 - name: restart dnsmasq
-  service: name=dnsmasq state=restarted enabled=yes
+  service: name=dnsmasq state=restarted 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,8 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - All
+    - name: EL
+      versions:
+        - 6
   categories:
     - system
-dependencies:
-  - { role: franklinkim.nginx, when: consul_is_ui == true }

--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -25,8 +25,11 @@
               line="conf-dir=/etc/dnsmasq.d" 
               state=present
 
+- name: ensure configure directory
+  file: dest=/etc/resolvconf/resolv.conf.d state=directory
+
 - name: add local dns lookup
-  lineinfile: line="nameserver 127.0.0.1" insertbefore=BOF state=present dest="/etc/resolv.conf"
+  lineinfile: line="nameserver 127.0.0.1" insertbefore=BOF state=present dest="/etc/resolvconf/resolv.conf.d/consul"
 
 - name: configure dnsmasq
   copy: >

--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -2,11 +2,31 @@
   apt: >
     update_cache=yes
     cache_valid_time=3600
+  when: ansible_os_family == "Debian"
 
-- name: install deps
+- name: install deps (Ubuntu)
   apt: >
     pkg=dnsmasq
     state=installed
+  when: ansible_os_family == "Debian"
+
+- name: install deps (RHEL)
+  yum: >
+    pkg=dnsmasq
+    state=installed
+  when: ansible_os_family == "RedHat"
+
+- name: ensure configure directory
+  file: dest=/etc/dnsmasq.d state=directory
+
+- name: ensure dnsmasq configuration
+  lineinfile: dest="/etc/dnsmasq.conf" 
+              regexp="^#conf-dir=/etc/dnsmasq.conf"
+              line="conf-dir=/etc/dnsmasq.d" 
+              state=present
+
+- name: add local dns lookup
+  lineinfile: line="nameserver 127.0.0.1" insertbefore=BOF state=present dest="/etc/resolv.conf"
 
 - name: configure dnsmasq
   copy: >
@@ -14,3 +34,6 @@
     dest=/etc/dnsmasq.d/10-consul
   notify:
     - restart dnsmasq
+
+- name: ensure dnsmasq running
+  service: name=dnsmasq state=running

--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -27,7 +27,7 @@
     owner=root
     group=root
     mode=0755
-  when: consul_is_ui
+  when: consul_enable_nginx_config
   notify:
     - restart nginx  
 
@@ -39,7 +39,7 @@
     owner=root
     group=root
     mode=0755
-  when: consul_is_ui and consul_enable_nginx_config
+  when: consul_enable_nginx_config
   notify:
   - restart nginx
 
@@ -52,3 +52,4 @@
     mode=0755
   notify:
     - restart nginx
+  when: consul_enable_nginx_config

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,14 +3,25 @@
   apt: >
     update_cache=yes
     cache_valid_time=3600
+  when: ansible_os_family == "Debian"
 
-- name: install deps
+- name: install deps (Ubuntu)
   apt: >
     pkg={{item}}
     state=installed
   with_items:
     - unzip
     - jq
+  when: ansible_os_family == "Debian"
+
+- name: install deps (RHEL)
+  yum: >
+    pkg={{item}}
+    state=installed
+  with_items:
+    - unzip
+    - jq
+  when: ansible_os_family == "RedHat"
 
 - name: download consul
   get_url: >
@@ -52,7 +63,6 @@
     owner={{consul_user}}
     group={{consul_group}}
     recurse=yes
-  when: consul_was_downloaded|changed
 
 - name: copy consul upstart script
   template: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,5 +2,5 @@
 - include: install.yml
 - { include: install-ui.yml, when: consul_is_ui == true }
 - include: dnsmasq.yml
-- include: consulate.yml
+- { include: consulate.yml, when: consul_consulate == true }
 - include: service.yml

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,4 +1,3 @@
 - service: >
     name=consul
     state=running
-    enabled=yes


### PR DESCRIPTION
I'm happy I came across this repo- I recently had to add Consul support for Centos, and found this the best starting point. I'm new to Ansible, and had to make some semi-opinionated choices to get it working, but I wanted to put it out there in case you were interested.

* Add support for Centos
* Removed NGINX requirement for UI. The ```franklinkim.nginx``` doesn't exist on ansible-galaxy (I couldn't install as a req) nor did I need/want NGINX. Instead, the UI option just enables the UI, and I modified the NGINX support to do a config only, assuming NGINX is already installed. 
* Made Consulate optional (I didn't need this, and seemed to have some install issues)
* Added 127.0.0.1 to /etc/resolve.conf; otherwise, I couldn't get dnsmasq working out-of-box with consul.

Feedback appreciate, or feel free to disregard if you're not interested.

Mike