### PR TITLE
Making consulate installation optional and minor fixes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,12 +22,13 @@ consul_log_level: "INFO"
 consul_syslog: false
 consul_rejoin_after_leave: true
 consul_leave_on_terminate: false
-consul_bind_address: "0.0.0.0"
+consul_bind_address: "{{ ansible_default_ipv4['address'] }}"
 consul_client_address: "127.0.0.1"
-consul_node_name: "{{ ansible_default_ipv4['address'] }}"
+consul_node_name: "{{ ansible_nodename }}"
 consul_datacenter: "default"
 consul_ui_require_auth: false
 consul_ui_auth_user_file: /etc/htpasswd/consul
 consul_enable_nginx_config: true
 consul_disable_remote_exec: true
-consul_install_dnsmasq: true
+consul_install_dnsmasq: false
+consul_install_consulate: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,11 +12,16 @@
     - unzip
     - jq
 
+- name: check archive existance
+  stat: path={{consul_download_folder}}/{{consul_archive}}
+  register: archive_downloaded
+
 - name: download consul
   get_url: >
     url={{consul_download}}
     dest={{consul_download_folder}}
   register: consul_was_downloaded
+  when: not archive_downloaded 
 
 - name: create consul directory
   file: >
@@ -48,11 +53,13 @@
 - name: set ownership
   file: >
     state=directory
-    path={{consul_home}}
+    path={{ item }}
     owner={{consul_user}}
     group={{consul_group}}
     recurse=yes
-  when: consul_was_downloaded|changed
+  with_items:
+    - "{{ consul_data_dir }}"
+    - "{{ consul_home }}"
 
 - name: copy consul upstart script
   template: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,5 +2,5 @@
 - include: install.yml
 - { include: install-ui.yml, when: consul_is_ui == true }
 - { include: dnsmasq.yml, when: consul_install_dnsmasq == true }
-- include: consulate.yml
+- { include: consulate.yml, when: consul_install_consulate == true }
 - include: service.yml

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -28,15 +28,12 @@
 {% if consul_is_server and consul_bootstrap_expect is defined %}
   "bootstrap_expect": {{ consul_bootstrap_expect }},
 {% endif %}
-{% if consul_encrypt_key is defined %}
-  "encrypt": "{{ consul_encrypt_key }}",
-{% endif %}
 {% if consul_watches is defined %}
   "watches": {{ consul_watches|to_nice_json }},
 {% endif %}
   "rejoin_after_leave": {{ "true" if consul_rejoin_after_leave else "false" }},
   "leave_on_terminate": {{ "true" if consul_leave_on_terminate else "false" }},
 {% if consul_encrypt is defined %}
-  "encrypt": {{ consul_encrypt }}
+  "encrypt": "{{ consul_encrypt }}"
 {% endif %}
 }


### PR DESCRIPTION
I made consulate installation optional as it was described in README.md, added archive download check to prevent file download if it's already existing. Also added default consul_node_name value as ansible_nodename.