### PR TITLE
Some (potentially) useful updates.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,7 +23,6 @@ consul_syslog: false
 consul_rejoin_after_leave: true
 consul_bind_address: "0.0.0.0"
 consul_client_address: "127.0.0.1"
-consul_node_name: "{{ ansible_default_ipv4['address'] }}"
 consul_datacenter: "default"
 consul_ui_require_auth: false
 consul_ui_auth_user_file: /etc/htpasswd/consul

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,4 @@ consul_ui_auth_user_file: /etc/htpasswd/consul
 consul_enable_nginx_config: true
 consul_disable_remote_exec: true
 consul_install_dnsmasq: true
+consul_leave_on_terminate: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,4 +30,3 @@ consul_ui_auth_user_file: /etc/htpasswd/consul
 consul_enable_nginx_config: true
 consul_disable_remote_exec: true
 consul_install_dnsmasq: true
-consul_leave_on_terminate: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -18,10 +18,22 @@
     dest={{consul_download_folder}}
   register: consul_was_downloaded
 
+- name: create consul group
+  group: >
+    name={{consul_group}}
+    state=present
+
+- name: create consul user
+  user: >
+    name={{consul_user}}
+    group={{consul_group}}
+
 - name: create consul directory
   file: >
     state=directory
     path={{ item }}
+    owner={{consul_user}}
+    group={{consul_group}}
   with_items:
     - "{{ consul_home }}"
     - "{{ consul_home }}/bin"
@@ -34,16 +46,6 @@
     dest={{ consul_home }}/bin
     copy=no
   when: consul_was_downloaded|changed
-
-- name: create consul group
-  group: >
-    name={{consul_group}}
-    state=present
-
-- name: create consul user
-  user: >
-    name={{consul_user}}
-    group={{consul_group}}
 
 - name: set ownership
   file: >

--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -1,7 +1,7 @@
 # Consul Agent (Upstart unit)
 description "Consul Agent"
 start on (local-filesystems and net-device-up IFACE!=lo)
-stop on runlevel [06]
+stop on runlevel [016]
 
 exec sudo -u {{ consul_user }} -g {{ consul_group }} {{ consul_home }}/bin/consul agent -config-dir {{ consul_config_dir }} -config-file={{ consul_config_file }} >> {{ consul_log_file }} 2>&1
 respawn

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -36,5 +36,6 @@
 {% if consul_watches is defined %}
   "watches": {{ consul_watches|to_nice_json }},
 {% endif %}
-  "rejoin_after_leave": {{ "true" if consul_rejoin_after_leave else "false" }}
+  "rejoin_after_leave": {{ "true" if consul_rejoin_after_leave else "false" }},
+  "leave_on_terminate": {{ "true" if consul_leave_on_terminate else "false" }}
 }

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -14,7 +14,9 @@
 {% if consul_syslog %}
   "enable_syslog": true,
 {% endif %}
+{% if consul_node_name is defined %}
   "node_name": "{{ consul_node_name }}",
+{% endif %}
   "server": {{ "true" if consul_is_server else "false" }},
   "client_addr": "{{ consul_client_address }}",
   "bind_addr": "{{ consul_bind_address }}",


### PR DESCRIPTION
I've been using your role for a couple of months now, it's solid work, thanks!

Here is a collection of things I've done to make it more useful for my use cases, and I thought you might want to talk about them.

The first thing I did was remove the default node name. I feel like this is safe because consul calculates a node name for you when it starts up, if you don't define one. In my use case, I have found myself *needing* that ;). 

We building AMIs as assets, and create instances using that AMI on demand in scaling groups. What that means is, when the machine is initially provisioned with this role, it creates a node name based on the hostname of the *build instance*. So, any future instance that is spun up using that AMI will be provisioned in consul with the *build instance* node name. That wasn't ideal, and got weird haha.

The next thing I did was to add the `leave_on_terminate` option as a var. The reason for this is similar to above. When the build instance was torn down, it was not correctly de-registering itself from the cluster. This option solves that, but is disabled by default (this should cover most use cases).

And lastly I moved the user creation up a bit in the run, and then create the directories with the new user/group.

Thoughts/Concerns?