### PR TITLE
Added information about the variable consul_join_at_start

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ consul_is_ui: "false"
 # configure consul to start in bootstrap mode
 consul_bootstrap: "false"
 consul_bootstrap_expect: 3
+# configure consul to join an existing cluster
+# note: no default available - behaves as "false" if not present, though
+consul_join_at_start: ~ 
 # configure service
 consul_servers: ['127.0.0.1']
 consul_log_level: "INFO"


### PR DESCRIPTION
Added the ``consul_join_at_start`` variable to the variables section of the README.

Currently, the ``consul_servers`` variable isn't used if the the ``consul_join_at_start`` is either absent or false.

Not sure if the variable is in the right place in the variables list, though. The same goes for the way it's documented with the "empty value" ``~`` and note about no default value.

Hope it can help in some way at least :-)