### PR TITLE
Setting GOMAXPROCS to the number of processors on the host

### DIFF
--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -6,6 +6,9 @@ stop on runlevel [016]
 
 script
 
+# Make sure to use all our CPUs, because Consul can block a scheduler thread
+export GOMAXPROCS=`nproc`
+
 {% if consul_dynamic_bind %}
 # Get the public IP
 BIND=`ifconfig eth0 | grep "inet addr" | awk '{ print substr($2,6) }'`

--- a/test/integration/default/serverspec/consul_spec.rb
+++ b/test/integration/default/serverspec/consul_spec.rb
@@ -11,6 +11,11 @@ describe 'Consul' do
     its(:content) { should match /"server": true/ }
   end
 
+  describe file('/etc/init/consul.conf') do
+    it { should be_file }
+    its(:content) { should match /export GOMAXPROCS=`nproc`/ }
+  end
+
   describe file('/var/log/consul') do
     it { should be_file }
   end


### PR DESCRIPTION
See https://groups.google.com/forum/#!topic/consul-tool/qewFEqgAoF8 for a discussion of why this is advisable.

Implementation shamelessly copied from: https://github.com/hashicorp/consul/blob/master/terraform/openstack/scripts/upstart.conf