### PR TITLE
README.md: Fix typo in `arm install` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ ansible-galaxy install savagegus.consul
 Using `arm` ([Ansible Role Manager](https://github.com/mirskytech/ansible-role-manager/)):
 
 ```
-$ arm install savagegus.ansible-consul
+$ arm install savagegus.consul
 ```
 
 Using `git`:


### PR DESCRIPTION
`arm install savagegus.consul` works for me. What's there with `ansible-consul` doesn't.