### PR TITLE
consul_install_dnsmasq: false

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ consul_client_address: "127.0.0.1"
 consul_datacenter: "default"
 consul_disable_remote_exec: true
 
-consul_install_dnsmasq: true
+consul_install_dnsmasq: false
 consul_install_consulate: false
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,5 +39,5 @@ consul_client_address: "127.0.0.1"
 consul_datacenter: "default"
 consul_disable_remote_exec: true
 
-consul_install_dnsmasq: true
+consul_install_dnsmasq: false
 consul_install_consulate: false


### PR DESCRIPTION
because I tried out this role a few days ago and today a couple of my Ops guys were asking me why dnsmasq is installed on our test servers :-)

It's safer to not install extra packages.