### PR TITLE
Install jq from upstream instead of from apt

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 consul_version: 0.5.2
 consul_archive: "{{ consul_version }}_linux_amd64.zip"
 consul_download: "https://dl.bintray.com/mitchellh/consul/{{ consul_archive }}"
+consul_jq_bin: "{{ consul_download_folder }}/jq"
+consul_jq_download: "http://stedolan.github.io/jq/download/linux{{ ansible_userspace_bits }}/jq"
 consul_download_folder: /tmp
 
 consul_is_ui: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,7 +10,12 @@
     state=installed
   with_items:
     - unzip
-    - jq
+
+- name: download jq
+  get_url: >
+    url={{consul_jq_download}}
+    dest={{consul_jq_bin}}
+  register: jq_was_downloaded
 
 - name: download consul
   get_url: >

--- a/templates/consulkv.j2
+++ b/templates/consulkv.j2
@@ -6,10 +6,10 @@ CONSUL="http://127.0.0.1:8500"
 main() {
   case "$1" in
     info)
-      curl -s "$CONSUL/v1/kv/$2" | jq -r .[]
+      curl -s "$CONSUL/v1/kv/$2" | {{consul_jq_bin}} -r .[]
       ;;
     get)
-      curl -s "$CONSUL/v1/kv/$2" | jq -r .[].Value | base64 -d | sed 's/$/\n/'
+      curl -s "$CONSUL/v1/kv/$2" | {{consul_jq_bin}} -r .[].Value | base64 -d | sed 's/$/\n/'
       ;;
     set)
       curl -s -X PUT -d "$3" "$CONSUL/v1/kv/$2" > /dev/null
@@ -19,9 +19,9 @@ main() {
       ;;
     ls)
       if [[ "$2" == "" ]]; then
-        curl -s "$CONSUL/v1/kv/?keys" | jq -r .[]
+        curl -s "$CONSUL/v1/kv/?keys" | {{consul_jq_bin}} -r .[]
       else
-        curl -s "$CONSUL/v1/kv/$2/?keys" | jq -r .[] | sed "s|$2/||"
+        curl -s "$CONSUL/v1/kv/$2/?keys" | {{consul_jq_bin}} -r .[] | sed "s|$2/||"
       fi
       ;;
   esac


### PR DESCRIPTION
I needed this because I was trying to install consul to Ubuntu 10.04 and
12.04 machines and this was failing because these don't have `jq` in the
offical apt repos.

So I instead get the latest version of jq from the project itself as it
is trivial to install as it is just one single statically linked binary.

Cc: @sudarkoff, @aconrad