### PR TITLE
when tls encryption and https api are enabled, consul user don't have permission to run consul https api on port 443

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -27,6 +27,7 @@
   user: >
     name={{consul_user}}
     group={{consul_group}}
+    system=yes
 
 - name: create consul directory
   file: >

--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -14,7 +14,7 @@ export GOMAXPROCS=`nproc`
 BIND=`ifconfig eth0 | grep "inet addr" | awk '{ print substr($2,6) }'`
 {% endif %}
 
-exec sudo -u {{ consul_user }} -g {{ consul_group }} {{ consul_home }}/bin/consul agent \
+sudo setcap CAP_NET_BIND_SERVICE=+eip /opt/consul/bin/consul; exec sudo -u {{ consul_user }} -g {{ consul_group }} {{ consul_home }}/bin/consul agent \
 {% if consul_dynamic_bind %}
   -bind=$BIND \
 {% endif %}

--- a/test/integration/default/serverspec/dnsmasq_spec.rb
+++ b/test/integration/default/serverspec/dnsmasq_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'dnsmasq' do
   describe service('dnsmasq') do
-    it { should be_enabled }
-    it { should be_running }
+    it { should_not be_enabled }
+    it { should_not be_running }
   end
 end

--- a/test/integration/tls/serverspec/consul_tls_spec.rb
+++ b/test/integration/tls/serverspec/consul_tls_spec.rb
@@ -39,4 +39,9 @@ describe 'Consul with TLS enabled' do
     it { should be_enabled }
     it { should be_running }
   end
+
+  describe file('/etc/init/consul.conf') do
+    it { should be_file }
+    its(:content) { should match /sudo setcap CAP_NET_BIND_SERVICE=+eip \/opt\/consul\/bin\/consul/ }
+  end
 end

--- a/test/integration/tls/serverspec/consul_tls_spec.rb
+++ b/test/integration/tls/serverspec/consul_tls_spec.rb
@@ -42,6 +42,6 @@ describe 'Consul with TLS enabled' do
 
   describe file('/etc/init/consul.conf') do
     it { should be_file }
-    its(:content) { should match /sudo setcap CAP_NET_BIND_SERVICE=+eip \/opt\/consul\/bin\/consul/ }
+    its(:content) { should match /sudo setcap CAP_NET_BIND_SERVICE=\+eip \/opt\/consul\/bin\/consul; exec sudo -u consul -g consul \/opt\/consul\/bin\/consul agent \\/ }
   end
 end


### PR DESCRIPTION
changes included;

- change consul to system account
- allow consul to open port 443 for https api
- include testing
