### PR TITLE
enabling http(s) api to bind to public IP and rpc to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ consul_leave_on_terminate: false
 consul_bind_address: "0.0.0.0"
 consul_dynamic_bind: false
 consul_client_address: "127.0.0.1"
+consul_client_address_bind: false
 consul_datacenter: "default"
 consul_disable_remote_exec: true
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,7 @@ consul_leave_on_terminate: false
 consul_bind_address: "0.0.0.0"
 consul_dynamic_bind: false
 consul_client_address: "127.0.0.1"
+consul_client_address_bind: false
 consul_datacenter: "default"
 consul_disable_remote_exec: true
 

--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -14,7 +14,7 @@ export GOMAXPROCS=`nproc`
 BIND=`ifconfig eth0 | grep "inet addr" | awk '{ print substr($2,6) }'`
 {% endif %}
 
-% if consul_client_address_bind %}
+{% if consul_client_address_bind %}
 # Get the public IP
 CLIENT_BIND=`ifconfig eth0 | grep "inet addr" | awk '{ print substr($2,6) }'`
 {% endif %}

--- a/templates/consul.conf.j2
+++ b/templates/consul.conf.j2
@@ -14,9 +14,17 @@ export GOMAXPROCS=`nproc`
 BIND=`ifconfig eth0 | grep "inet addr" | awk '{ print substr($2,6) }'`
 {% endif %}
 
+% if consul_client_address_bind %}
+# Get the public IP
+CLIENT_BIND=`ifconfig eth0 | grep "inet addr" | awk '{ print substr($2,6) }'`
+{% endif %}
+
 sudo setcap CAP_NET_BIND_SERVICE=+eip /opt/consul/bin/consul; exec sudo -u {{ consul_user }} -g {{ consul_group }} {{ consul_home }}/bin/consul agent \
 {% if consul_dynamic_bind %}
   -bind=$BIND \
+{% endif %}
+{% if consul_client_address_bind %}
+  -client=$CLIENT_BIND \
 {% endif %}
   -config-dir {{ consul_config_dir }} \
   -config-file={{ consul_config_file }} \

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -18,6 +18,12 @@
   "node_name": "{{ consul_node_name }}",
 {% endif %}
   "server": {{ "true" if consul_is_server else "false" }},
+{% if consul_client_address_bind and consul_client_address is defined and consul_client_address is not none %}
+  "client_addr": "{{ consul_client_address }}",
+  "addresses" : {
+    "rpc": "127.0.0.1"
+  },
+{% endif %}
   "client_addr": "{{ consul_client_address }}",
 {% if consul_dynamic_bind == false and consul_bind_address is defined and consul_bind_address is not none %}
   "bind_addr": "{{ consul_bind_address }}",


### PR DESCRIPTION
when client_addr or -client is set to public IP http/https/rpc/dns
are bound to that IP. the normal consul command will fail without
adding additional parameter (-rpc-addr/-http-addr) as part of the command. 
this change will let you make fine grain adjustment to configure http(s) api to listen to public IP but remain rpc to listen to bind to localhost.