### PR TITLE
Add statsd_addr support to Consul config

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ consul_atlas_token: "your_consul_token"
 consul_atlas_join: true
 ```
 
+## Other Variables
+
+```yml
+# if you Consul to send metrics to a statsd instance
+consul_statsd_address: "127.0.0.1"
+```
+
+
 ## Handlers
 
 These are the handlers that are defined in `handlers/main.yml`.

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -97,6 +97,9 @@
 {% if consul_atlas_acl_token is defined %}
   "atlas_acl_token": "{{ consul_atlas_acl_token }}",
 {% endif %}
+{% if consul_statsd_address is defined %}
+  "statsd_addr": "{{ consul_statsd_address }}",
+{% endif %}
   "rejoin_after_leave": {{ "true" if consul_rejoin_after_leave else "false" }},
   "leave_on_terminate": {{ "true" if consul_leave_on_terminate else "false" }}
 }


### PR DESCRIPTION
This allows users to set `consul_statsd_address` to an address for statsd which Consul will send metrics to