### PR TITLE
Add statsite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ consul_statsd_address: "127.0.0.1:8125"
 # if you want Consul to send metrics to a statsite instance
 consul_statsite_address: "127.0.0.1:8125"
 # this sets the prefix consul uses for all metrics
-statsite_prefix: "consul"
+consul_statsite_prefix: "consul"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -134,11 +134,16 @@ consul_atlas_token: "your_consul_token"
 consul_atlas_join: true
 ```
 
-## Other Variables
+## Telemetry Variables
+Consul has excellent [telemetry support](https://www.consul.io/docs/agent/telemetry.html). To enable it, use any of the following variables:
 
 ```yml
-# if you Consul to send metrics to a statsd instance
-consul_statsd_address: "127.0.0.1"
+# if you want Consul to send metrics to a statsd instance
+consul_statsd_address: "127.0.0.1:8125"
+# if you want Consul to send metrics to a statsite instance
+consul_statsite_address: "127.0.0.1:8125"
+# this sets the prefix consul uses for all metrics
+statsite_prefix: "consul"
 ```
 
 

--- a/templates/consul.json.j2
+++ b/templates/consul.json.j2
@@ -100,6 +100,12 @@
 {% if consul_statsd_address is defined %}
   "statsd_addr": "{{ consul_statsd_address }}",
 {% endif %}
+{% if consul_statsite_address is defined %}
+  "statsite_addr": "{{ consul_statsite_address }}",
+{% endif %}
+{% if consul_statsite_prefix is defined %}
+  "statsite_prefix": "{{ consul_statsite_prefix }}",
+{% endif %}
   "rejoin_after_leave": {{ "true" if consul_rejoin_after_leave else "false" }},
   "leave_on_terminate": {{ "true" if consul_leave_on_terminate else "false" }}
 }


### PR DESCRIPTION
This PR allows users to set the `statsite_address` and/or `statsite_prefix`.

This is a continuation of #59.