### PR TITLE
Adding support for authentication when mirroring or using an artifact

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 consul_version: 0.5.2
 consul_archive: "{{ consul_version }}_linux_amd64.zip"
 consul_download: "https://dl.bintray.com/mitchellh/consul/{{ consul_archive }}"
+consul_download_username: ""
+consul_download_password: ""
 consul_download_folder: /tmp
 
 consul_is_ui: false

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,6 +16,8 @@
   get_url: >
     url={{consul_download}}
     dest={{consul_download_folder}}
+    url_username={{ consul_download_username }}
+    url_password={{ consul_download_password }}
   register: consul_was_downloaded
 
 - name: create consul group


### PR DESCRIPTION
repository to host the Consul download.

Default behavior of get_url when username and password are empty is to omit the Authorization header altogether.