### PR TITLE
allow dnsmasq to restart fully

### DIFF
--- a/tasks/dnsmasq.yml
+++ b/tasks/dnsmasq.yml
@@ -26,3 +26,4 @@
     dest=/etc/dnsmasq.d/10-consul
   notify:
     - restart dnsmasq
+- pause: minutes=1


### PR DESCRIPTION
when dnsmasq is enabled if no proper delay was in placed, succeeding job that uses dns fails. this allows dnsmasq to fully started before proceeding to the next step.