### PR TITLE
Download archives from web only if local files does not exists

### DIFF
--- a/tasks/install-ui.yml
+++ b/tasks/install-ui.yml
@@ -1,8 +1,13 @@
+- name: check ui archive stat
+  stat: path={{ consul_download_folder }}/{{ consul_ui_archive }}
+  register: consul_archive_ui_stat
+
 - name: download consul ui
   get_url: >
     url={{consul_ui_download}}
     dest={{consul_download_folder}}
   register: consul_ui_was_downloaded
+  when: consul_archive_ui_stat.stat.exists == False
 
 - name: copy and unpack ui
   unarchive: >

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,6 +12,10 @@
     - unzip
     - jq
 
+- name: check archive stat
+  stat: path={{ consul_download_folder }}/{{ consul_archive }}
+  register: consul_archive_stat
+
 - name: download consul
   get_url: >
     url={{consul_download}}
@@ -19,6 +23,7 @@
     url_username={{ consul_download_username }}
     url_password={{ consul_download_password }}
   register: consul_was_downloaded
+  when: consul_archive_stat.stat.exists == False
 
 - name: create consul group
   group: >


### PR DESCRIPTION
Sorry for my bad English.

In Ansible 1.9.4 [get_url module](http://docs.ansible.com/ansible/get_url_module.html) always download files even if they already exists on disk (option --force=no does not work properly as specified in manual).

My propose is to check if the files already exists.

Now, when role was executed first time:
```
TASK: [savagegus.consul | check archive stat] ******************************
<192.168.0.2> REMOTE_MODULE stat path=/tmp/0.5.2_linux_amd64.zip
ok: [host] => {"changed": false, "stat": {"exists": false}}

TASK: [savagegus.consul | download consul] ************************************
<192.168.0.2> REMOTE_MODULE get_url url=https://dl.bintray.com/mitchellh/consul/0.5.2_linux_amd64.zip dest=/tmp ...
changed: [host] => {"changed": true, "checksum": "...", ......}
```

And after role was executed second time, files was not downloaded again:
```
TASK: [savagegus.consul | check ui archive stat] ******************************
<192.168.0.2> REMOTE_MODULE stat path=/tmp/0.5.2_linux_amd64.zip
ok: [host] => {"changed": false, "stat": {..., ..., "exists": true, ...}}

TASK: [savagegus.consul | download consul] ************************************
skipping: [host]
```