### PR TITLE
Restoring proper metadata format

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,3 +12,4 @@ galaxy_info:
         - 7
   categories:
     - system
+dependencies: []


### PR DESCRIPTION
I think those got broken in the Centos7 PR, my apologies.